### PR TITLE
replaceAll to repalce

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -24,7 +24,7 @@ let CodeUtil = {
       .replace(".java", "")
       .replace(".ts", "")
       .replace(".js", "")
-      .replaceAll(/\//g, ".")
+      .replace(/\//g, ".")
       .replace(/.src./g, ".")
       .replace(/src./g, "main.");
   },


### PR DESCRIPTION
Use `replace` instead of `replaceAll` to support lower version browsers